### PR TITLE
Update base.go

### DIFF
--- a/base.go
+++ b/base.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// Version is the current version of ALLHIC
-	Version = "0.9.13"
+	Version = "0.9.14"
 	// LB is lower bound for GoldenArray
 	LB = 18
 	// UB is upper bound for GoldenArray


### PR DESCRIPTION
Updating the version (you will need to recompile the binaries of 0.9.14 with this change so they report as 0.9.14 instead of 0.9.13)